### PR TITLE
Release v1.1.1 — chore: set docker image tag to be 'latest'

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -4,7 +4,7 @@ services:
             context: .
             dockerfile: eureka-server/Dockerfile
         container_name: eureka-server
-        image: ${DOCKER_USER:-eun61n}/weave-eureka-server:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-eureka-server:latest"
         ports:
             - "8761:8761"
         networks:
@@ -27,7 +27,7 @@ services:
             context: .
             dockerfile: config-server/Dockerfile
         container_name: config-server
-        image: ${DOCKER_USER:-eun61n}/weave-config-server:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-config-server:latest"
         ports:
             - "8888:8888"
         environment:
@@ -54,7 +54,7 @@ services:
             context: .
             dockerfile: auth-service/Dockerfile
         container_name: auth-service
-        image: ${DOCKER_USER:-eun61n}/weave-auth-service:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-auth-service:latest"
         ports:
             - "8081:8081"
         networks:
@@ -70,7 +70,7 @@ services:
             context: .
             dockerfile: user-service/Dockerfile
         container_name: user-service
-        image: ${DOCKER_USER:-eun61n}/weave-user-service:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-user-service:latest"
         ports:
             - "8082:8082"
         networks:
@@ -91,7 +91,7 @@ services:
             context: .
             dockerfile: quiz-service/Dockerfile
         container_name: quiz-service
-        image: ${DOCKER_USER:-eun61n}/weave-quiz-service:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-quiz-service:latest"
         ports:
             - "8083:8083"
         networks:
@@ -112,7 +112,7 @@ services:
             context: .
             dockerfile: gateway/Dockerfile
         container_name: gateway
-        image: ${DOCKER_USER:-eun61n}/weave-gateway:${GIT_TAG:-latest}
+        image: "${DOCKER_USER:-eun61n}/weave-gateway:latest"
         ports:
             - "8080:8080"
         networks:


### PR DESCRIPTION
Release v1.1.1 — chore: set docker image tag to be 'latest'