### PR TITLE
feat/26 표준 예외처리 시스템(중앙화) 구현

### DIFF
--- a/backend/auth-service/src/main/java/com/weave/authservice/exception/ErrorMap.java
+++ b/backend/auth-service/src/main/java/com/weave/authservice/exception/ErrorMap.java
@@ -1,0 +1,20 @@
+package com.weave.authservice.exception;
+
+import com.weave.common.exception.ErrorMapInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMap implements ErrorMapInterface {
+
+    // Auth 3XXX
+    UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, 3000, "UnauthorizedError", "인증 정보가 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final int errorCode;
+    private final String errorName;
+    private final String message;
+
+}

--- a/backend/auth-service/src/main/java/com/weave/authservice/exception/GlobalExceptionHandler.java
+++ b/backend/auth-service/src/main/java/com/weave/authservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.weave.authservice.exception;
+
+import com.weave.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(WeaveAuthException.class)
+    public ResponseEntity<Object> handleWeaveUserException(WeaveAuthException e) {
+        log.error("[WeaveUserException] HttpStatus: {}, Message: {}", e.getHttpStatus(), e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(e.getErrorResponse());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("[AccessDeniedException] {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN.value(), 4030, "ACCESS_DENIED", "You do not have permission to access this resource.");
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(errorResponse);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.error("[Spring MVC Exception] HttpStatus: {}, Message: {}", statusCode, ex.getMessage());
+
+        // @Valid 에러
+        if (ex instanceof MethodArgumentNotValidException) {
+            String errorMessage = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldErrors().stream()
+                    .map(fieldError -> String.format("'%s': %s", fieldError.getField(), fieldError.getDefaultMessage()))
+                    .collect(Collectors.joining(", "));
+            
+            ErrorResponse errorResponse = ErrorResponse.of(statusCode.value(), 4001, "INVALID_INPUT_VALUE", errorMessage);
+            return ResponseEntity.status(statusCode).body(errorResponse);
+        }
+
+        // 그 외 Spring 기본 예외
+        ErrorResponse errorResponse = ErrorResponse.of(statusCode.value(), statusCode.value() * 10, ex.getClass().getSimpleName(), ex.getLocalizedMessage());
+        return ResponseEntity.status(statusCode).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleGlobalException(Exception e) {
+        log.error("[Unhandled Exception] An unexpected error occurred", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), 9999, e.getClass().getSimpleName(), "An internal server error has occurred.");
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse);
+    } 
+}

--- a/backend/auth-service/src/main/java/com/weave/authservice/exception/WeaveAuthException.java
+++ b/backend/auth-service/src/main/java/com/weave/authservice/exception/WeaveAuthException.java
@@ -1,0 +1,16 @@
+package com.weave.authservice.exception;
+
+import com.weave.common.exception.WeaveException;
+
+import java.util.Arrays;
+
+public class WeaveAuthException extends WeaveException {
+
+    public WeaveAuthException(ErrorMap errorMap) {
+        super(errorMap);
+    }
+
+    public WeaveAuthException(ErrorMap errorMap, String args) {
+        super(errorMap, args);
+    }
+}

--- a/backend/common/build.gradle
+++ b/backend/common/build.gradle
@@ -25,7 +25,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Jackson
+	implementation 'org.springframework.boot:spring-boot-starter-json'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/common/src/main/java/com/weave/common/dto/ErrorResponse.java
+++ b/backend/common/src/main/java/com/weave/common/dto/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.weave.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+    @JsonProperty("error_code") private final int errorCode;
+    @JsonProperty("error_name")private final String errorName;
+    private final String message;
+    private final LocalDateTime timestamp = LocalDateTime.now();
+
+    public static ErrorResponse of(int statusCode, int errorCode, String errorName, String message) {
+        return ErrorResponse.builder()
+                .status(statusCode)
+                .errorCode(errorCode)
+                .errorName(errorName)
+                .message(message)
+                .build();
+    }
+
+}

--- a/backend/common/src/main/java/com/weave/common/exception/ErrorMapInterface.java
+++ b/backend/common/src/main/java/com/weave/common/exception/ErrorMapInterface.java
@@ -1,0 +1,12 @@
+package com.weave.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorMapInterface {
+
+    HttpStatus getHttpStatus();
+    int getErrorCode();
+    String getErrorName();
+    String getMessage();
+
+}

--- a/backend/common/src/main/java/com/weave/common/exception/WeaveException.java
+++ b/backend/common/src/main/java/com/weave/common/exception/WeaveException.java
@@ -1,0 +1,38 @@
+package com.weave.common.exception;
+
+import com.weave.common.dto.ErrorResponse;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class WeaveException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final ErrorResponse errorResponse;
+
+    public WeaveException(ErrorMapInterface errorMap) {
+        this.httpStatus = errorMap.getHttpStatus();
+        this.message = errorMap.getMessage();
+        this.errorResponse = ErrorResponse.of(
+                errorMap.getHttpStatus().value(),
+                errorMap.getErrorCode(),
+                errorMap.getErrorName(),
+                errorMap.getMessage()
+        );
+    }
+
+    public WeaveException(ErrorMapInterface errorMap, String args) {
+        String formattedMessage = String.format(errorMap.getMessage(), args);
+
+        this.httpStatus = errorMap.getHttpStatus();
+        this.message = formattedMessage;
+        this.errorResponse = ErrorResponse.of(
+                errorMap.getHttpStatus().value(),
+                errorMap.getErrorCode(),
+                errorMap.getErrorName(),
+                formattedMessage
+        );
+    }
+
+}

--- a/backend/gateway/build.gradle
+++ b/backend/gateway/build.gradle
@@ -42,6 +42,13 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Internal project dependency
+    implementation project(':common')
 }
 
 dependencyManagement {

--- a/backend/gateway/src/main/java/com/weave/gateway/exception/GlobalErrorWebExceptionHandler.java
+++ b/backend/gateway/src/main/java/com/weave/gateway/exception/GlobalErrorWebExceptionHandler.java
@@ -1,0 +1,81 @@
+package com.weave.gateway.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.weave.common.dto.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+@Order(-1)
+public class GlobalErrorWebExceptionHandler implements ErrorWebExceptionHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> handle(ServerWebExchange exchange, Throwable ex) {
+        log.error("Global Error Handler caught an exception: {}", ex.getMessage());
+
+        HttpStatus status;
+        String errorCode;
+        String message;
+
+        if (ex instanceof ResponseStatusException responseStatusException) {
+            status = (HttpStatus) responseStatusException.getStatusCode();
+            errorCode = status.name();
+            if (status == HttpStatus.NOT_FOUND) {
+                errorCode = "ROUTE_NOT_FOUND";
+                message = "요청하신 API를 찾을 수 없습니다.";
+                log.error("[ROUTE_NOT_FOUND] Route not found for the request: {}", exchange.getRequest().getURI());
+            } else if (status == HttpStatus.SERVICE_UNAVAILABLE) {
+                errorCode = "SERVICE_UNAVAILABLE";
+                message = "현재 해당 서비스가 점검 중이거나 사용할 수 없습니다. 잠시 후 다시 시도해주세요.";
+                log.error("[SERVICE_UNAVAILABLE] Service unavailable for the request: {}", exchange.getRequest().getURI());
+            }else {
+                message = switch (status) {
+                    case UNAUTHORIZED -> "인증 정보가 유효하지 않습니다. 다시 로그인해주세요.";
+                    case FORBIDDEN -> "해당 기능에 접근할 권한이 없습니다.";
+                    default -> responseStatusException.getReason();
+                };
+                log.error("[ResponseStatusException] Status: {}, Reason: {}", status, message);
+            }
+        } else if (ex.getCause() instanceof TimeoutException) {
+            status = HttpStatus.GATEWAY_TIMEOUT;
+            errorCode = "GATEWAY_TIMEOUT";
+            message = "서버 응답이 늦어지고 있습니다. 잠시 후 다시 시도해주세요.";
+            log.error("[TimeoutException] Response from downstream service timed out.");
+
+        } else {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+            errorCode = "INTERNAL_SERVER_ERROR";
+            message = "서버 내부에 예기치 못한 오류가 발생했습니다. 관리자에게 문의해주세요.";
+            log.error("[Unhandled Exception] An unexpected error occurred", ex);
+        }
+
+        ErrorResponse errorResponse = ErrorResponse.of(status.value(), 9990, errorCode, message);
+        exchange.getResponse().setStatusCode(status);
+        exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
+            DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(bytes);
+            return exchange.getResponse().writeWith(Mono.just(buffer));
+        } catch (JsonProcessingException e) {
+            log.error("Error while serializing ErrorResponse", e);
+            return Mono.empty();
+        }
+    }
+}

--- a/backend/gateway/src/main/java/com/weave/gateway/filter/AuthenticationFilter.java
+++ b/backend/gateway/src/main/java/com/weave/gateway/filter/AuthenticationFilter.java
@@ -10,8 +10,8 @@ import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFac
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
@@ -74,10 +74,9 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
         }
     }
 
-    private Mono<Void> onError(ServerWebExchange exchange, String errorMessage, HttpStatus httpStatus) {
-        ServerHttpResponse response = exchange.getResponse();
-        response.setStatusCode(httpStatus);
-        return response.setComplete();
+    private Mono<Void> onError(ServerWebExchange exchange, String err, HttpStatus httpStatus) {
+        ResponseStatusException ex = new ResponseStatusException(httpStatus, err);
+        return Mono.error(ex);
     }
 
     public static class Config {

--- a/backend/user-service/src/main/java/com/weave/userservice/exception/ErrorMap.java
+++ b/backend/user-service/src/main/java/com/weave/userservice/exception/ErrorMap.java
@@ -1,0 +1,26 @@
+package com.weave.userservice.exception;
+
+import com.weave.common.exception.ErrorMapInterface;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMap implements ErrorMapInterface {
+
+    // User 2XXX
+    USER_ALREADY_EXIST_ERROR(HttpStatus.CONFLICT, 2000, "UserAlreadyExistError", "이미 가입된 유저입니다: $s"),
+    NICKNAME_ALREADY_EXIST_ERROR(HttpStatus.CONFLICT, 2001, "NicknameAlreadyExistError", "이미 존재하는 닉네임입니다: %s"),
+    UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, 2002, "UnauthorizedError", "관리자 계정만 접근 가능합니다."),
+    USER_NOT_FOUND_ERROR(HttpStatus.BAD_REQUEST, 2003, "UserNotFoundError", "사용자를 찾을 수 없습니다: $s"),
+    WRONG_PASSWORD_ERROR(HttpStatus.BAD_REQUEST, 2004, "WrongPasswordError", "잘못된 비밀번호입니다."),
+    INVALID_EMAIL_PATTERN_ERROR(HttpStatus.BAD_REQUEST, 2005, "InvalidEmailPatternError", "이메일 형식이 올바르지 않습니다: %s"),
+    INVALID_PASSWORD_PATTERN_ERROR(HttpStatus.BAD_REQUEST, 2006, "InvalidPasswordPatternError", "비밀번호 형식이 올바르지 않습니다");
+
+    private final HttpStatus httpStatus;
+    private final int errorCode;
+    private final String errorName;
+    private final String message;
+
+}

--- a/backend/user-service/src/main/java/com/weave/userservice/exception/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/com/weave/userservice/exception/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.weave.userservice.exception;
+
+import com.weave.common.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(WeaveUserException.class)
+    public ResponseEntity<Object> handleWeaveUserException(WeaveUserException e) {
+        log.error("[WeaveUserException] HttpStatus: {}, Message: {}", e.getHttpStatus(), e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(e.getErrorResponse());
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("[AccessDeniedException] {}", e.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.FORBIDDEN.value(), 4030, "ACCESS_DENIED", "You do not have permission to access this resource.");
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(errorResponse);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.error("[Spring MVC Exception] HttpStatus: {}, Message: {}", statusCode, ex.getMessage());
+
+        // @Valid 에러
+        if (ex instanceof MethodArgumentNotValidException) {
+            String errorMessage = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldErrors().stream()
+                    .map(fieldError -> String.format("'%s': %s", fieldError.getField(), fieldError.getDefaultMessage()))
+                    .collect(Collectors.joining(", "));
+            
+            ErrorResponse errorResponse = ErrorResponse.of(statusCode.value(), 4001, "INVALID_INPUT_VALUE", errorMessage);
+            return ResponseEntity.status(statusCode).body(errorResponse);
+        }
+
+        // 그 외 Spring 기본 예외
+        ErrorResponse errorResponse = ErrorResponse.of(statusCode.value(), statusCode.value() * 10, ex.getClass().getSimpleName(), ex.getLocalizedMessage());
+        return ResponseEntity.status(statusCode).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleGlobalException(Exception e) {
+        log.error("[Unhandled Exception] An unexpected error occurred", e);
+        ErrorResponse errorResponse = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), 9999, e.getClass().getSimpleName(), "An internal server error has occurred.");
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse);
+    } 
+}

--- a/backend/user-service/src/main/java/com/weave/userservice/exception/WeaveUserException.java
+++ b/backend/user-service/src/main/java/com/weave/userservice/exception/WeaveUserException.java
@@ -1,0 +1,17 @@
+package com.weave.userservice.exception;
+
+import com.weave.common.exception.WeaveException;
+import lombok.Getter;
+
+@Getter
+public class WeaveUserException extends WeaveException{
+
+    public WeaveUserException(ErrorMap errorMap) {
+        super(errorMap);
+    }
+
+    public WeaveUserException(ErrorMap errorMap, String args) {
+        super(errorMap);
+    }
+
+}

--- a/backend/user-service/src/main/java/com/weave/userservice/service/UserService.java
+++ b/backend/user-service/src/main/java/com/weave/userservice/service/UserService.java
@@ -6,6 +6,7 @@ import com.weave.userservice.dto.request.SignupRequest;
 import com.weave.userservice.dto.request.UpdateRefreshTokenRequest;
 import com.weave.userservice.dto.response.UserResponse;
 import com.weave.userservice.entity.User;
+import com.weave.userservice.exception.WeaveUserException;
 import com.weave.userservice.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,7 @@ import org.springframework.stereotype.Service;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.weave.common.exception.ErrorMap.*;
+import static com.weave.userservice.exception.ErrorMap.*;
 
 @Service
 @RequiredArgsConstructor
@@ -37,9 +38,9 @@ public class UserService {
 
     public UserResponse checkLoginCredentials(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new WeaveException(USER_NOT_FOUND_ERROR));
+                .orElseThrow(() -> new WeaveUserException(USER_NOT_FOUND_ERROR, request.getEmail()));
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new WeaveException(WRONG_PASSWORD_ERROR);
+            throw new WeaveUserException(WRONG_PASSWORD_ERROR);
         }
         return UserResponse.of(user);
     }
@@ -47,14 +48,14 @@ public class UserService {
     @Transactional
     public void updateRefreshToken(UpdateRefreshTokenRequest request) {
         User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new WeaveException(USER_NOT_FOUND_ERROR));
+                .orElseThrow(() -> new WeaveUserException(USER_NOT_FOUND_ERROR, request.getUserId().toString()));
         user.setRefreshToken(request.getRefreshToken());
         userRepository.save(user);
     }
 
     public UserResponse getUserInfo(String userId) {
         User user = userRepository.findById(Long.valueOf(userId))
-                .orElseThrow(() -> new WeaveException(USER_NOT_FOUND_ERROR));
+                .orElseThrow(() -> new WeaveUserException(USER_NOT_FOUND_ERROR, userId));
         return UserResponse.of(user);
     }
 
@@ -63,17 +64,17 @@ public class UserService {
         String regex = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$"; // XXX@XXX.XXX
         Pattern p = Pattern.compile(regex);
         Matcher m = p.matcher(request.getEmail());
-        if (!m.matches()) throw new WeaveException(EMAIL_PATTERN_ERROR);
+        if (!m.matches()) throw new WeaveUserException(INVALID_EMAIL_PATTERN_ERROR, request.getEmail());
 
         // validate password pattern
         regex = "^(?=.*[0-9])(?=.*[A-Za-z]).{8,30}$"; // 영문, 숫자를 포함한 8 - 30자리
         p = Pattern.compile(regex);
         m = p.matcher(request.getPassword());
-        if (!m.matches()) throw new WeaveException(PASSWORD_PATTERN_ERROR);
+        if (!m.matches()) throw new WeaveUserException(INVALID_PASSWORD_PATTERN_ERROR);
 
         // validate nickname duplication
         if (userRepository.existsByNickname(request.getNickname())) {
-            throw new WeaveException(NICKNAME_ALREADY_EXIST_ERROR);
+            throw new WeaveUserException(NICKNAME_ALREADY_EXIST_ERROR, request.getNickname());
         }
     }
 


### PR DESCRIPTION
## PR 유형
어떤 유형의 PR인가요?

- [x] Feat: 새로운 기능 추가
- [ ] Fix: 버그 수정
- [x] Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] Docs: 문서 변경
- [ ] Chore: 빌드, 의존성, 기타 설정 변경 (코드 변경 없음)
- [ ] Test: 테스트 코드 추가/수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락 등 (코드 의미 변경 없음)

## 관련 이슈
- Closes #26 

## 변경 사항 요약
MSA 아키텍처 전반에 걸쳐 일관되고 확장성 있는 예외 처리 시스템을 구축
- 기존에는 각 서비스가 개별적으로 에러를 처리하여 응답 형식이 제각각이었고, 예측하지 못한 예외 발생 시 500 에러와 함께 불친절한 메시지가 반환
- 이번 변경을 통해 common 모듈에 표준 예외 처리 기반을 마련하고, 각 서비스가 이를 상속받아 구현하도록 구조를 개선 → 모든 서비스가 항상 동일한 형식의 에러 응답을 반환하도록 보장하여, 클라이언트의 에러 처리 로직을 단순화하고 시스템 전체의 안정성과 유지보수성을 향상

## 주요 변경 내용
1. common 모듈: 표준 예외 처리 기반 확립
  - `ErrorMapInterface` 인터페이스: 모든 서비스의 에러 코드 `Enum`이 구현해야 할 표준 계약(`HttpStatus`, `code`, `message`)을 정의
  -`WeaveException` 최상위 비즈니스 exception 추상 클래스: 모든 커스텀 비즈니스 예외의 부모 클래스로, `ErrorMapInterface`을 통해 일관된 예외 정보를 갖도록 강제
 - `ErrorResponse` DTO: 모든 에러 응답이 클라이언트에게 동일한 JSON 형식으로 전달되도록 표준 응답 DTO를 정의
2. 각 서비스: 표준 예외 처리 시스템 적용 (user-service, auth-service)
  - `GlobalExceptionHandler` 개선: `ResponseEntityExceptionHandler`를 상속받도록 리팩토링하여, 코드 중복 없이 Spring MVC의 다양한 표준 예외(`@Valid` 실패, 타입 불일치, 잘못된 HTTP 메소드 등)를 효율적으로 처리하도록 수정
  - `ErrorMap` 수정: 각 서비스의 기존 `ErrorMap` Enum이 `common` 모듈의 `ErrorMapInterface` 인터페이스를 구현하도록 수정
  - `WeaveUserException`, `WeaveAuthException` 등 수정: 각 서비스의 커스텀 예외 클래스가 `common` 모듈의 `WeaveException`을 상속받도록 구조를 변경하여, 예외 클래스의 역할을 명확히 하고 보일러플레이트 코드를 제거

## 테스트 방법
로컬 환경에서 Postman을 사용하여 테스트를 진행
1. 비즈니스 예외: 유효한 토큰과 함께, 존재하지 않는 유저 ID로 `GET /api/v1/users`를 요청
  `404 NOT_FOUND` 상태 코드와 함께, UserNotFoundError `ErrorResponse` 정상 반환 확인
2. 유효성 검증 예외: `POST /api/v1/users/signup` 요청 시, nickname을 누락하여 요청
  `400 BAD_REQUEST` 상태 코드의 표준 `ErrorResponse` 정상 반환 확인
3. 프레임워크 예외: POST만 허용하는 `/api/v1/users/signup` API에 GET 메소드로 요청
  `405 METHOD_NOT_ALLOWED` 상태 코드의 표준 `ErrorResponse` 정상 반환 확인

## 스크린샷 (UI 변경이 있는 경우)
- 해당사항 없음

## 특이 사항 또는 주의 사항
- 각 서비스(`user-service`, `auth-service` 등)의 설정 파일에 아래 설정이 추가되어야 `404 Not Found` 예외 핸들러가 정상적으로 동작
```
  spring:
    mvc:
      throw-exception-if-no-handler-found: true
    web:
      resources:
        add-mappings: false
  ```
- 앞으로 새로운 마이크로서비스를 추가할 경우, 반드시 `common` 모듈에 대한 의존성을 추가하고 `GlobalExceptionHandler`를 구현하여 표준 예외 처리 전략을 따라야 함.
